### PR TITLE
Fixing bug where having no data context would break sharing

### DIFF
--- a/client/views/facebook/facebook.coffee
+++ b/client/views/facebook/facebook.coffee
@@ -1,10 +1,8 @@
 Template.shareit_facebook.rendered = ->
-    return unless @data
-
     @autorun ->
-        template = Template.instance()        
-        data = Template.currentData()
-        
+        template = Template.instance()
+        data = Template.currentData() || ShareIt.defaultDataContext()
+
         $('meta[property^="og:"]').remove()
         #
         # OpenGraph tags
@@ -17,7 +15,7 @@ Template.shareit_facebook.rendered = ->
         $('<meta>', { property: 'og:url', content: url }).appendTo 'head'
         $('<meta>', { property: 'og:title', content: title }).appendTo 'head'
         $('<meta>', { property: 'og:description', content: description }).appendTo 'head'
-        
+
         if data.thumbnail
             if typeof data.thumbnail == "function"
                 img = data.thumbnail()
@@ -26,9 +24,9 @@ Template.shareit_facebook.rendered = ->
         if img
             if not /^http(s?):\/\/+/.test(img)
                 img = location.origin + img
-                
+
         $('<meta>', { property: 'og:image', content: img }).appendTo 'head'
-        
+
         if ShareIt.settings.sites.facebook.appId?
             template.$('.fb-share').click (e) ->
                 e.preventDefault()
@@ -45,9 +43,9 @@ Template.shareit_facebook.rendered = ->
             href = base + "?s=100&p[url]=" + url + "&p[title]=" + title + "&p[summary]=" + summary
             if img
                 href += "&p[images][0]=" + encodeURIComponent img
-    
+
             template.$(".fb-share").attr "href", href
-            
+
     return
-    
+
 Template.shareit_facebook.helpers(ShareIt.helpers)

--- a/client/views/googleplus/googleplus.coffee
+++ b/client/views/googleplus/googleplus.coffee
@@ -1,11 +1,9 @@
 Template.shareit_googleplus.rendered = () ->
-    return unless @data
-
     @autorun ->
         template = Template.instance()
-        data = Template.currentData()
+        data = Template.currentData() || ShareIt.defaultDataContext()
         $('meta[itemscope]').remove()
-        
+
         #
         # Schema tags
         #
@@ -17,7 +15,7 @@ Template.shareit_googleplus.rendered = () ->
         $('<meta>', { itemprop: 'name', content: location.hostname }).appendTo 'head'
         $('<meta>', { itemprop: 'url', content: url }).appendTo 'head'
         $('<meta>', { itemprop: 'description', content: description }).appendTo 'head'
-        
+
         if data.thumbnail
             if typeof data.thumbnail == "function"
                 img = data.thumbnail()
@@ -26,12 +24,12 @@ Template.shareit_googleplus.rendered = () ->
         if img
             if not /^http(s?):\/\/+/.test(img)
                 img = location.origin + img
-                
+
         $('<meta>', { itemprop: 'image', content: img }).appendTo 'head'
         #
         # Google share button
         #
-      
+
         href = "https://plus.google.com/share?url=#{url}"
         template.$(".googleplus-share").attr "href", href
 

--- a/client/views/pinterest/pinterest.coffee
+++ b/client/views/pinterest/pinterest.coffee
@@ -1,18 +1,16 @@
 Template.shareit_pinterest.rendered = ->
-    return unless @data
-
     @autorun ->
         template = Template.instance()
-        data = Template.currentData()
-        
+        data = Template.currentData() || ShareIt.defaultDataContext()
+
         preferred_url = data.url || location.origin + location.pathname
         url = encodeURIComponent preferred_url
         description = encodeURIComponent data.pinterest?.description || data.description
-    
+
         href = "http://www.pinterest.com/pin/create/button/?url=#{url}&media=#{data.media}&description=#{description}"
-        
+
         template.$('.pinterest-share').attr 'href', href
-    
+
 Template.shareit_pinterest.events
     'click a': (event, template) ->
         event.preventDefault()

--- a/client/views/twitter/twitter.coffee
+++ b/client/views/twitter/twitter.coffee
@@ -1,11 +1,9 @@
 Template.shareit_twitter.rendered = ->
-    return unless @data
-
     @autorun ->
         template = Template.instance()
-        data = Template.currentData()
+        data = Template.currentData() || ShareIt.defaultDataContext()
         $('meta[property^="twitter:"]').remove()
-      
+
         if data.thumbnail
           if typeof data.thumbnail == "function"
             img = data.thumbnail()
@@ -14,38 +12,38 @@ Template.shareit_twitter.rendered = ->
           if img
             if not /^http(s?):\/\/+/.test(img)
               img = location.origin + img
-      
+
         #
         # Twitter cards
         #
-      
+
         $('<meta>', { property: 'twitter:card', content: 'summary' }).appendTo 'head'
         # What should go here?
         #$('<meta>', { property: 'twitter:site', content: '' }).appendTo 'head'
-      
+
         if data.author
           $('<meta>', { property: 'twitter:creator', content: data.author }).appendTo 'head'
-      
+
         description = data.twitter?.description || data.excerpt || data.description || data.summary
         $('<meta>', { property: 'twitter:url', content: location.origin + location.pathname }).appendTo 'head'
         $('<meta>', { property: 'twitter:title', content: "#{data.title}" }).appendTo 'head'
         $('<meta>', { property: 'twitter:description', content: description }).appendTo 'head'
         $('<meta>', { property: 'twitter:image', content: img }).appendTo 'head'
-      
+
         #
         # Twitter share button
         #
-      
+
         preferred_url = data.url || location.origin + location.pathname
         url = encodeURIComponent preferred_url
-      
+
         base = "https://twitter.com/intent/tweet"
         text = encodeURIComponent data.twitter?.title || data.title
         href = base + "?url=" + url + "&text=" + text
-      
+
         if data.author
           href += "&via=" + data.author
-      
+
         template.$(".tw-share").attr "href", href
 
 

--- a/shareit.coffee
+++ b/shareit.coffee
@@ -2,7 +2,7 @@ ShareIt = {
   settings:
     autoInit: true
     buttons: 'responsive'
-    sites: 
+    sites:
       'facebook':
         'appId': null
         'version': 'v2.1'
@@ -24,7 +24,13 @@ ShareIt = {
 
   configure: (hash) ->
     @settings = $.extend(true, @settings, hash)
-  
+
+  defaultDataContext: () ->
+    {
+      url: location.origin + location.pathname,
+      title: document.title
+    }
+
   helpers: {
     classes: () ->
       ShareIt.settings.classes
@@ -46,7 +52,7 @@ ShareIt = {
 
 ShareIt.init = (hash) ->
   @settings = $.extend(true, @settings, hash)
-    
+
   # Twitter
   window.twttr = do (d = document, s = 'script', id = 'twitter-wjs') ->
     t = undefined
@@ -69,7 +75,7 @@ ShareIt.init = (hash) ->
   if ShareIt.settings.autoInit
     window.fbAsyncInit = ->
       FB.init(ShareIt.settings.sites.facebook)
-    
+
   ((d, s, id) ->
     js = undefined
     fjs = d.getElementsByTagName(s)[0]
@@ -81,4 +87,3 @@ ShareIt.init = (hash) ->
     fjs.parentNode.insertBefore js, fjs
     return
   ) document, 'script', 'facebook-jssdk'
-  


### PR DESCRIPTION
My editor also stripped out a bunch of white space, sorry about that.  This change should make it so if you have no data context it'll still use the current url as the url and the page's title as the title.