### PR TITLE
Allows multiple shareIt button sets, for different URL's

### DIFF
--- a/client/views/facebook/facebook.coffee
+++ b/client/views/facebook/facebook.coffee
@@ -4,19 +4,29 @@ Template.shareit_facebook.rendered = ->
     @autorun ->
         template = Template.instance()        
         data = Template.currentData()
-        
-        $('meta[property^="og:"]').remove()
+        # console.log(data)
+
+        noMeta=data.url && (data.url!=(location.origin + location.pathname))
+
+        if not noMeta
+            $('meta[property^="og:"]').remove()
         #
         # OpenGraph tags
         #
         description = data.facebook?.description || data.excerpt || data.description || data.summary
         url = data.url || location.origin + location.pathname
         title = data.title
-        $('<meta>', { property: 'og:type', content: 'article' }).appendTo 'head'
-        $('<meta>', { property: 'og:site_name', content: location.hostname }).appendTo 'head'
-        $('<meta>', { property: 'og:url', content: url }).appendTo 'head'
-        $('<meta>', { property: 'og:title', content: title }).appendTo 'head'
-        $('<meta>', { property: 'og:description', content: description }).appendTo 'head'
+        
+        if not noMeta
+            $('<meta>', { property: 'og:type', content: 'article' }).appendTo 'head'
+        if not noMeta
+            $('<meta>', { property: 'og:site_name', content: location.hostname }).appendTo 'head'
+        if not noMeta
+            $('<meta>', { property: 'og:url', content: url }).appendTo 'head'
+        if not noMeta
+            $('<meta>', { property: 'og:title', content: title }).appendTo 'head'
+        if not noMeta
+            $('<meta>', { property: 'og:description', content: description }).appendTo 'head'
         
         if data.thumbnail
             if typeof data.thumbnail == "function"
@@ -27,7 +37,8 @@ Template.shareit_facebook.rendered = ->
             if not /^http(s?):\/\/+/.test(img)
                 img = location.origin + img
                 
-        $('<meta>', { property: 'og:image', content: img }).appendTo 'head'
+        if not noMeta
+            $('<meta>', { property: 'og:image', content: img }).appendTo 'head'
         
         if ShareIt.settings.sites.facebook.appId?
             template.$('.fb-share').click (e) ->

--- a/client/views/facebook/facebook.coffee
+++ b/client/views/facebook/facebook.coffee
@@ -7,7 +7,8 @@ Template.shareit_facebook.rendered = ->
         # console.log(data)
 
         noMeta=data.url && (data.url!=(location.origin + location.pathname))
-
+        # console.log(data.url)
+        # console.log((location.origin + location.pathname))
         if not noMeta
             $('meta[property^="og:"]').remove()
         #

--- a/client/views/googleplus/googleplus.coffee
+++ b/client/views/googleplus/googleplus.coffee
@@ -4,7 +4,10 @@ Template.shareit_googleplus.rendered = () ->
     @autorun ->
         template = Template.instance()
         data = Template.currentData()
-        $('meta[itemscope]').remove()
+        noMeta=data.url && (data.url!=(location.origin + location.pathname))
+
+        if not noMeta 
+            $('meta[itemscope]').remove()
         
         #
         # Schema tags
@@ -13,10 +16,14 @@ Template.shareit_googleplus.rendered = () ->
         url = data.url || location.origin + location.pathname
         title = data.title
         itemtype = data.googleplus?.itemtype || 'Article'
-        $('html').attr('itemscope', '').attr('itemtype', "http://schema.org/#{itemtype}")
-        $('<meta>', { itemprop: 'name', content: location.hostname }).appendTo 'head'
-        $('<meta>', { itemprop: 'url', content: url }).appendTo 'head'
-        $('<meta>', { itemprop: 'description', content: description }).appendTo 'head'
+        if not noMeta 
+            $('html').attr('itemscope', '').attr('itemtype', "http://schema.org/#{itemtype}")
+        if not noMeta
+            $('<meta>', { itemprop: 'name', content: location.hostname }).appendTo 'head'
+        if not noMeta 
+            $('<meta>', { itemprop: 'url', content: url }).appendTo 'head'
+        if not noMeta 
+            $('<meta>', { itemprop: 'description', content: description }).appendTo 'head'
         
         if data.thumbnail
             if typeof data.thumbnail == "function"
@@ -27,7 +34,8 @@ Template.shareit_googleplus.rendered = () ->
             if not /^http(s?):\/\/+/.test(img)
                 img = location.origin + img
                 
-        $('<meta>', { itemprop: 'image', content: img }).appendTo 'head'
+        if not noMeta 
+            $('<meta>', { itemprop: 'image', content: img }).appendTo 'head'
         #
         # Google share button
         #

--- a/client/views/pinterest/pinterest.coffee
+++ b/client/views/pinterest/pinterest.coffee
@@ -4,6 +4,7 @@ Template.shareit_pinterest.rendered = ->
     @autorun ->
         template = Template.instance()
         data = Template.currentData()
+        noMeta=data.url && (data.url!=(location.origin + location.pathname))
         
         preferred_url = data.url || location.origin + location.pathname
         url = encodeURIComponent preferred_url

--- a/client/views/twitter/twitter.coffee
+++ b/client/views/twitter/twitter.coffee
@@ -4,7 +4,10 @@ Template.shareit_twitter.rendered = ->
     @autorun ->
         template = Template.instance()
         data = Template.currentData()
-        $('meta[property^="twitter:"]').remove()
+        noMeta=data.url && (data.url!=(location.origin + location.pathname))
+
+        if not noMeta 
+            $('meta[property^="twitter:"]').remove()
       
         if data.thumbnail
           if typeof data.thumbnail == "function"
@@ -19,18 +22,24 @@ Template.shareit_twitter.rendered = ->
         # Twitter cards
         #
       
-        $('<meta>', { property: 'twitter:card', content: 'summary' }).appendTo 'head'
+        if not noMeta 
+            $('<meta>', { property: 'twitter:card', content: 'summary' }).appendTo 'head'
         # What should go here?
         #$('<meta>', { property: 'twitter:site', content: '' }).appendTo 'head'
       
         if data.author
-          $('<meta>', { property: 'twitter:creator', content: data.author }).appendTo 'head'
+          if not noMeta 
+              $('<meta>', { property: 'twitter:creator', content: data.author }).appendTo 'head'
       
         description = data.twitter?.description || data.excerpt || data.description || data.summary
-        $('<meta>', { property: 'twitter:url', content: location.origin + location.pathname }).appendTo 'head'
-        $('<meta>', { property: 'twitter:title', content: "#{data.title}" }).appendTo 'head'
-        $('<meta>', { property: 'twitter:description', content: description }).appendTo 'head'
-        $('<meta>', { property: 'twitter:image', content: img }).appendTo 'head'
+        if not noMeta 
+            $('<meta>', { property: 'twitter:url', content: location.origin + location.pathname }).appendTo 'head'
+        if not noMeta 
+            $('<meta>', { property: 'twitter:title', content: "#{data.title}" }).appendTo 'head'
+        if not noMeta 
+            $('<meta>', { property: 'twitter:description', content: description }).appendTo 'head'
+        if not noMeta 
+            $('<meta>', { property: 'twitter:image', content: img }).appendTo 'head'
       
         #
         # Twitter share button


### PR DESCRIPTION
Prevents <meta> tag creation if provided URL does not match current URL.

The problem was, that on my pages, containing a lot 'cards', each having own shareIt buttons (pointing to different URL's), the assumption was made that that same page needs all the <meta> stuff in it's <head> section. Which is plain wrong! This patch prevents <meta> creation when the current page is not the actual URL provided.

No configuring required